### PR TITLE
feat: added pseudo labeler script

### DIFF
--- a/decavision/dataset_preparation/__init__.py
+++ b/decavision/dataset_preparation/__init__.py
@@ -1,2 +1,3 @@
 from . import data_augmentation
 from . import generate_tfrecords
+from . import generate_pseudolabels

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -173,7 +173,7 @@ class PseudoLabelGenerator:
         raw_predictions = []  # single confidence value of predicted class
         predicted_class = []  # predicted class index
         raw_predictions_all = []  # confidences for all classes
-        for path in tqdm(unlabeled_image_paths[:100]):
+        for path in tqdm(unlabeled_image_paths):
             # Load the image
             img = np.array(self._load_img(os.path.join(self.unlabeled_path, path),
                                           target_size=(299, 299)))
@@ -214,7 +214,3 @@ class PseudoLabelGenerator:
                     csv_path="outputs/data.csv", classes=class_names)
             else:
                 print("No CSV file is present to plot the data.")
-
-
-if __name__ == '__main__':
-    transformer = PseudoLabelGenerator()

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -15,22 +15,29 @@ class PseudoLabelGenerator:
     """
     Class to generate pseudo labels.
     Arguments:
-        model_path (str): path to trained model
-        train_path (str): path to training data
-        unlabeled_path (str): path to unlabeled data
-        pseudo_path (str): path to store train data and pseudo data
+        model_path (str): folder which stores the trained model
+        train_path (str): folder which holds training data
+        unlabeled_path (str): folder which holds unlabeled data
+        pseudo_path (str): folder to store training data and pseudo data combined
+        output_folder (str): folder to store outputs
+        csv_path (str): name of csv file
     """
 
-    def __init__(self, model_path, train_data_path, unlabeled_path, pseudo_data_path):
+    def __init__(self, model_path="model", train_data_path="data/image_dataset/train", unlabeled_path="data/image_dataset/unlabeled", pseudo_data_path="data/image_dataset/train_ssl", output_folder="outputs", csv_path="data.csv"):
         self.model_path = model_path
         self.train_data_path = train_data_path
         self.unlabeled_path = unlabeled_path
         self.pseudo_data_path = pseudo_data_path
+        self.output_folder = output_folder
+        self.csv_path = csv_path
 
         # Load model
-        model = load_model(self.model_path, compile=False)
-        self.model = model
+        self.model = load_model(self.model_path, compile=False)
         print("Loaded model.")
+
+        # Make new output folder
+        if not os.path.exists(self.output_folder):
+            os.mkdir(self.output_folder)
 
     def _load_img(self, path, target_size=(299, 299)):
         """
@@ -64,7 +71,7 @@ class PseudoLabelGenerator:
             output_path (str): Save file using this name
         """
         predictions = sorted(predictions)
-        samples = [pred for pred in range(len(predictions))]
+        samples = list(range(len(predictions)))
         plt.bar(samples, predictions, color='g')
         plt.axhline(y=0.5, color='r', linestyle='--')
         plt.title(name, size=16)
@@ -75,52 +82,52 @@ class PseudoLabelGenerator:
         plt.savefig(output_path, dpi=100)
         plt.clf()  # clear buffer, otherwise plot overlap!
 
-    def _plot_confidence_scores(self, csv_path, classes):
+    def _plot_confidence_scores(self, classes):
         """
         Save pseudo label names and their confidence scores in a csv file.
 
         Arguments:
-            csv_path (str): Path to save SCV file
             classes (list): List containing the class names
         """
-        dt = pd.read_csv(csv_path)
+        dt = pd.read_csv(os.path.join(self.output_folder, self.csv_path))
         dt['All Class Predictions List'] = dt['All Class Predictions'].apply(
             lambda x: ast.literal_eval(x))
 
         raw_predictions_ = dt[["Highest Confidence"]].values
-        raw_predictions = [raw_predictions_[idx][0]
-                           for idx in range(len(raw_predictions_))]
+        raw_predictions = [pred[0] for pred in raw_predictions_]
 
         raw_predictions_all_ = dt[['All Class Predictions List']].values
-        raw_predictions_all = [raw_predictions_all_[idx][0]
-                               for idx in range(len(raw_predictions_all_))]
+        raw_predictions_all = [pred[0] for pred in raw_predictions_all_]
 
         # Plot graph for highest confidence pseudo labels for each class
-        for idx in range(len(classes)):
-            predictions = []
-            for i in raw_predictions_all:
-                predictions.append(i[idx])
 
+        for idx, _ in enumerate(classes):
+            predictions = [pred[idx] for pred in raw_predictions_all]
             title = "Confidences for the class: {}".format(classes[idx])
-            path = "outputs/{}_confidences.png".format(classes[idx])
+            path = "{}/{}_confidences.png".format(
+                self.output_folder, classes[idx])
             self._plot_data(predictions, title, path)
 
         # Plot graph for highest confidence pseudo labels for all unlabeled images
         self._plot_data(raw_predictions,
                         name="Highest confidence pseudo labels",
-                        output_path="outputs/highest_confidence_predictions.png")
+                        output_path="{}/highest_confidence_predictions.png".format(
+                            self.output_folder))
 
-    def _save_pseudo_labels(self, csv_path, threshold, dictionary):
+    def _move_unlabeled_images(self, threshold, dictionary):
         """
         Save pseudo labels.
 
         Arguments:
-            csv_path (str): Path to CSV file
             threshold (float): Discard images with prediction below this confidence, default is None.
             dictionary (dict): Class dictionary
         """
 
-        dt = pd.read_csv(csv_path)
+        # Copy the training/labeled data to the destination folder where
+        # we will also store the pseudo labels.
+        copy_tree(self.train_data_path, self.pseudo_data_path)
+
+        dt = pd.read_csv(os.path.join(self.output_folder, self.csv_path))
         filepaths = dt[["Filepaths"]].values
         predicted_class = dt[["Predicted Class"]].values
         raw_predictions = dt[["Highest Confidence"]].values
@@ -152,17 +159,9 @@ class PseudoLabelGenerator:
                 pseudo_data_path: A folder with both labeled and pseudo labeled images.
         """
 
-        # Copy the training/labeled data to the destination folder where
-        # we will also store the pseudo labels.
-        copy_tree(self.train_data_path, self.pseudo_data_path)
-
         # Make dictionary for classes and their index
         class_names = sorted(os.listdir(self.train_data_path))
-        class_dict = {}
-        index = 0
-        for cat in class_names:
-            class_dict[cat] = index
-            index += 1
+        class_dict = {cat: i for (i, cat) in enumerate(class_names)}
 
         print("Generating pseudo labels...")
         # Generate pseudo labels
@@ -199,18 +198,17 @@ class PseudoLabelGenerator:
                     'Highest Confidence': raw_predictions,
                     'All Class Predictions': raw_predictions_all}
             df = pd.DataFrame(data)
-            df.to_csv("outputs/data.csv", index=False)
+            df.to_csv(os.path.join(self.output_folder,
+                      self.csv_path), index=False)
 
         # Save pseudo labeled images
-        self._save_pseudo_labels(csv_path="outputs/data.csv",
-                                 threshold=threshold,
-                                 dictionary=class_dict)
+        self._move_unlabeled_images(threshold=threshold,
+                                    dictionary=class_dict)
 
         if plot_confidences:
             # Plot only if there are any CSV files.
             if save_confidences_csv:
                 print("Plotting data.")
-                self._plot_confidence_scores(
-                    csv_path="outputs/data.csv", classes=class_names)
+                self._plot_confidence_scores(classes=class_names)
             else:
                 print("No CSV file is present to plot the data.")

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -194,7 +194,6 @@ class PseudoLabelGenerator:
         print("There are {} unlabeled images.".format(
             len(unlabeled_image_paths)))
 
-        raw_predictions_paths = []
         raw_predictions = []  # single confidence value of predicted class
         predicted_class = []  # predicted class index
         raw_predictions_all = []  # confidences for all classes

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -1,22 +1,36 @@
+import ast
 import os
+import shutil
+from distutils.dir_util import copy_tree
+
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import tensorflow as tf
-import numpy as np
-import shutil
-import matplotlib.pyplot as plt
-
 from tensorflow.keras.models import load_model
-from distutils.dir_util import copy_tree
 from tqdm import tqdm
 
 
 class PseudoLabelGenerator:
     """
-    Class to make pseudo labels.
+    Class to generate pseudo labels.
+    Arguments:
+        model_path (str): path to trained model
+        train_path (str): path to training data
+        unlabeled_path (str): path to unlabeled data
+        pseudo_path (str): path to store train data and pseudo data
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, model_path, train_data_path, unlabeled_path, pseudo_data_path):
+        self.model_path = model_path
+        self.train_data_path = train_data_path
+        self.unlabeled_path = unlabeled_path
+        self.pseudo_data_path = pseudo_data_path
+
+        # Load model
+        model = load_model(self.model_path, compile=False)
+        self.model = model
+        print("Loaded model.")
 
     def _load_img(self, path, target_size=(299, 299)):
         """
@@ -40,16 +54,97 @@ class PseudoLabelGenerator:
         image = image.numpy()
         return image
 
-    def generate_pseudolabel_data(self, model_path,
-                                  train_data_path, unlabeled_path,
-                                  pseudo_data_path, save_confidences_csv=False,
+    def _plot_data(self, predictions, name, output_path):
+        """
+        Plots a bar plot.
+
+        Arguments:
+            predictions (list): List of predictions
+            name (str): Title of the plot
+            output_path (str): Save file using this name
+        """
+        predictions = sorted(predictions)
+        samples = [pred for pred in range(len(predictions))]
+        plt.bar(samples, predictions, color='g')
+        plt.axhline(y=0.5, color='r', linestyle='--')
+        plt.title(name, size=16)
+        plt.xlabel("Number of unlabelled images", size=16)
+        plt.ylim([0.0, 1.0])
+        plt.ylabel("Probability", size=16)
+        plt.tick_params(labelright=True)
+        plt.savefig(output_path, dpi=100)
+        plt.clf()  # clear buffer, otherwise plot overlap!
+
+    def _plot_confidence_scores(self, csv_path, classes):
+        """
+        Save pseudo label names and their confidence scores in a csv file.
+
+        Arguments:
+            csv_path (str): Path to save SCV file
+            classes (list): List containing the class names
+        """
+        dt = pd.read_csv(csv_path)
+        dt['All Class Predictions List'] = dt['All Class Predictions'].apply(
+            lambda x: ast.literal_eval(x))
+
+        raw_predictions_ = dt[["Highest Confidence"]].values
+        raw_predictions = [raw_predictions_[idx][0]
+                           for idx in range(len(raw_predictions_))]
+
+        raw_predictions_all_ = dt[['All Class Predictions List']].values
+        raw_predictions_all = [raw_predictions_all_[idx][0]
+                               for idx in range(len(raw_predictions_all_))]
+
+        # Plot graph for highest confidence pseudo labels for each class
+        for idx in range(len(classes)):
+            predictions = []
+            samples = []
+            for i in raw_predictions_all:
+                predictions.append(i[idx])
+
+            title = "Confidences for the class: {}".format(classes[idx])
+            path = "outputs/{}_confidences.png".format(classes[idx])
+            self._plot_data(predictions, title, path)
+
+        # Plot graph for highest confidence pseudo labels for all unlabeled images
+        self._plot_data(raw_predictions,
+                        name="Highest confidence pseudo labels",
+                        output_path="outputs/highest_confidence_predictions.png")
+
+    def _save_pseudo_labels(self, csv_path, threshold, dictionary):
+        """
+        Save pseudo labels.
+
+        Arguments:
+            csv_path (str): Path to CSV file
+            threshold (float): Discard images with prediction below this confidence, default is None.
+            dictionary (dict): Class dictionary
+        """
+
+        dt = pd.read_csv(csv_path)
+        filepaths = dt[["Filepaths"]].values
+        predicted_class = dt[["Predicted Class"]].values
+        raw_predictions = dt[["Highest Confidence"]].values
+
+        for proba, y, path in zip(raw_predictions, predicted_class, filepaths):
+            # The results variable should be the same as the class category
+            for class_name, index in dictionary.items():
+                if threshold:
+                    # For thresholding predictions
+                    if index == y and proba >= threshold:
+                        shutil.copy(os.path.join(self.unlabeled_path, str(path[0])),
+                                    os.path.join(self.pseudo_data_path, class_name))
+                else:
+                    # For hard predictions
+                    if index == y:
+                        shutil.copy(os.path.join(self.unlabeled_path, str(path[0])),
+                                    os.path.join(self.pseudo_data_path, class_name))
+        print("Saved pseudo labels.")
+
+    def generate_pseudolabel_data(self, save_confidences_csv=False,
                                   plot_confidences=False, threshold=None):
         """ Convert image and label to tfrecord example.
             Arguments:
-                model_path (str): path to trained model
-                train_path (str): path to training data
-                unlabeled_path (str): path to unlabeled data
-                pseudo_path (str): path to store train data and pseudo data
                 save_confidences_csv (boolean): Whether to save CSV file with pseudo confidences, default is False.
                 plot_confidences (boolean): Whether to plot confidence graphs for raw confidences and per class confidences.
                 threshold (float): Discard images with prediction below this confidence, default is None.
@@ -57,16 +152,13 @@ class PseudoLabelGenerator:
             Returns:
                 pseudo_data_path: A folder with both labeled and pseudo labeled images.
         """
+
         # Copy the training/labeled data to the destination folder where
         # we will also store the pseudo labels.
-        copy_tree(train_data_path, pseudo_data_path)
-
-        # Load model
-        model = load_model(model_path, compile=False)
-        print("Loaded model.")
+        copy_tree(self.train_data_path, self.pseudo_data_path)
 
         # Make dictionary for classes and their index
-        class_names = sorted(os.listdir(train_data_path))
+        class_names = sorted(os.listdir(self.train_data_path))
         class_dict = {}
         index = 0
         for cat in class_names:
@@ -75,84 +167,55 @@ class PseudoLabelGenerator:
 
         print("Generating pseudo labels...")
         # Generate pseudo labels
-        unlabeled_image_paths = os.listdir(unlabeled_path)
+        unlabeled_image_paths = os.listdir(self.unlabeled_path)
         print("There are {} unlabeled images.".format(
             len(unlabeled_image_paths)))
         raw_predictions_paths = []
         raw_predictions = []  # single confidence value of predicted class
+        predicted_class = []  # predicted class index
         raw_predictions_all = []  # confidences for all classes
+        pseudo_class_names = []  # name of pseudo class
         for path in tqdm(unlabeled_image_paths[:100]):
             # Load the image
-            img = np.array(self._load_img(os.path.join(unlabeled_path, path),
+            img = np.array(self._load_img(os.path.join(self.unlabeled_path, path),
                                           target_size=(299, 299)))
             # Make predictions using trained model
-            y_pred = model.predict(np.expand_dims(img, axis=0), verbose=0)
+            y_pred = self.model.predict(np.expand_dims(img, axis=0), verbose=0)
             # Get class index
             y = np.argmax(y_pred)
             # Get probability score
             proba = y_pred[0][y]
 
+            predicted_class.append(y)
             raw_predictions.append(proba)
-            raw_predictions_all.append(y_pred)
-            raw_predictions_paths.append(os.path.join(unlabeled_path, path))
-
-            # The results variable should be the same as the class category
-            for class_name, index in class_dict.items():
-                if threshold:
-                    # For thresholding predictions
-                    if index == y and proba >= threshold:
-                        shutil.copy(os.path.join(unlabeled_path, path),
-                                    os.path.join(pseudo_data_path, class_name))
-                else:
-                    # For hard predictions
-                    if index == y:
-                        shutil.copy(os.path.join(unlabeled_path, path),
-                                    os.path.join(pseudo_data_path, class_name))
-        print("Generated pseudo labels.")
+            raw_predictions_all.append(list(y_pred[0]))
+            raw_predictions_paths.append(path)
 
         if not os.path.exists("outputs"):
             os.mkdir("outputs")
         if save_confidences_csv:
+            # 'Pseudo Class Names': pseudo_class_names,
             print("Saving CSV with pseudo predictions.")
-            data = {'filepaths': raw_predictions_paths,
-                    'class preds highest': raw_predictions,
-                    'class preds all': raw_predictions_all}
+            data = {'Filepaths': raw_predictions_paths,
+                    'Predicted Class': predicted_class,
+                    'Highest Confidence': raw_predictions,
+                    'All Class Predictions': raw_predictions_all}
             df = pd.DataFrame(data)
-            df.to_csv("outputs/pseudo_predictions.csv", index=False)
+            df.to_csv("outputs/data.csv", index=False)
+
+        # Save pseudo labeled images
+        self._save_pseudo_labels(csv_path="outputs/data.csv",
+                                 threshold=threshold,
+                                 dictionary=class_dict)
 
         if plot_confidences:
-            # Plot graph for highest confidence pseudo labels for each class
-            for idx in range(len(class_names)):
-                predictions = []
-                samples = []
-                for i in raw_predictions_all:
-                    predictions.append(i[0][idx])
-
-                predictions = sorted(predictions)
-                samples = [pred for pred in range(len(predictions))]
-                plt.bar(samples, predictions, color='g')
-                plt.axhline(y=0.5, color='r', linestyle='--')
-                plt.title("Confidences for the class: {}".format(
-                    class_names[idx]), size=16)
-                plt.xlabel("Number of unlabelled images", size=16)
-                plt.ylim([0.0, 1.0])
-                plt.ylabel("Probability", size=16)
-                plt.tick_params(labelright=True)
-                plt.savefig(
-                    "outputs/{}_confidences.png".format(class_names[idx]), dpi=100)
-                plt.clf()  # clear buffer, otherwise plot overlap!
-
-            # Plot graph for highest confidence pseudo labels for all unlabeled images
-            predictions_highest = sorted(raw_predictions)
-            samples_highest = [pred for pred in range(len(raw_predictions))]
-            plt.bar(samples_highest, predictions_highest, color='g')
-            plt.title("Highest confidence pseudo labels", size=16)
-            plt.xlabel("Number of unlabelled images", size=16)
-            plt.ylim([0.0, 1.0])
-            plt.ylabel("Probability", size=16)
-            plt.tick_params(labelright=True)
-            plt.savefig("outputs/highest_confidence_predictions.png", dpi=100)
-            plt.clf()
+            # Plot only if there are any CSV files.
+            if save_confidences_csv:
+                print("Plotting data.")
+                self._plot_confidence_scores(
+                    csv_path="outputs/data.csv", classes=class_names)
+            else:
+                print("No CSV file is present to plot the data.")
 
 
 if __name__ == '__main__':

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -203,7 +203,12 @@ class PseudoLabelGenerator:
         unlabeled_filenames = [os.path.join(self.unlabeled_path,
                                             path) for path in unlabeled_image_paths]
         ds = self._make_dataset(unlabeled_filenames, batch_size)
-        y_preds = self.model.predict(ds)
+
+        y_preds = []
+        for batch in tqdm(ds):
+            y_preds_ = self.model.predict(batch)
+            y_preds.extend(list(y_preds_))
+
         for y_pred in y_preds:
             y = np.argmax(y_pred)
             # Get probability score

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -1,0 +1,162 @@
+import csv
+import math
+import os
+import pandas as pd
+import tensorflow as tf
+import numpy as np
+import shutil
+import matplotlib.pyplot as plt
+
+from PIL import Image
+from tensorflow.keras.models import load_model
+from distutils.dir_util import copy_tree
+from tqdm import tqdm
+
+
+class PseudoLabelGenerator:
+    """
+    Class to make pseudo labels.
+    """
+
+    def __init__(self):
+        pass
+
+    def _load_img(self, path, target_size=(299, 299)):
+        """
+        Load an image from a given path and normalize it
+
+        Args:
+            path (list): Input image path
+            target_size (tuple): Size of image
+        Returns:
+            np.array: Numpy array of the data
+        """
+        # Read image
+        bits = tf.io.read_file(path)
+        image = tf.image.decode_jpeg(bits, channels=3)
+        # Resize
+        image = tf.image.resize(image, size=[*target_size])
+        image = tf.reshape(image, [*target_size, 3])
+        image = tf.cast(image, tf.uint8)
+        # Normalize [0, 1]
+        image = tf.image.convert_image_dtype(image, dtype=tf.float32)
+        image = image.numpy()
+        return image
+
+    def generate_pseudolabel_data(self, model_path,
+                                  train_data_path, unlabeled_path,
+                                  pseudo_data_path, save_confidences_csv=False,
+                                  plot_confidences=False, threshold=None):
+        """ Convert image and label to tfrecord example.
+            Arguments:
+                model_path (str): path to trained model
+                train_path (str): path to training data
+                unlabeled_path (str): path to unlabeled data
+                pseudo_path (str): path to store train data and pseudo data
+                save_confidences_csv (boolean): Whether to save CSV file with pseudo confidences, default is False.
+                plot_confidences (boolean): Whether to plot confidence graphs for raw confidences and per class confidences.
+                threshold (float): Discard images with prediction below this confidence, default is None. 
+
+            Returns:
+                pseudo_data_path: A folder with both labeled and pseudo labeled images.
+        """
+        # Copy the training/labeled data to the destination folder where
+        # we will also store the pseudo labels.
+        copy_tree(train_data_path, pseudo_data_path)
+
+        # Load model
+        model = load_model(model_path, compile=False)
+        print("Loaded model.")
+
+        # Make dictionary for classes and their index
+        class_names = sorted(os.listdir(train_data_path))
+        class_dict = {}
+        index = 0
+        for cat in class_names:
+            class_dict[cat] = index
+            index += 1
+
+        print("Generating pseudo labels...")
+        # Generate pseudo labels
+        unlabeled_image_paths = os.listdir(unlabeled_path)
+        print("There are {} unlabeled images.".format(
+            len(unlabeled_image_paths)))
+        raw_predictions_paths = []
+        raw_predictions = []  # single confidence value of predicted class
+        raw_predictions_all = []  # confidences for all classes
+        for path in tqdm(unlabeled_image_paths[:100]):
+            # Load the image
+            img = np.array(self._load_img(os.path.join(unlabeled_path, path),
+                                          target_size=(299, 299)))
+            # Make predictions using trained model
+            y_pred = model.predict(np.expand_dims(img, axis=0), verbose=0)
+            # Get class index
+            y = np.argmax(y_pred)
+            # Get probability score
+            proba = y_pred[0][y]
+
+            raw_predictions.append(proba)
+            raw_predictions_all.append(y_pred)
+            raw_predictions_paths.append(os.path.join(unlabeled_path, path))
+
+            # The results variable should be the same as the class category
+            for class_name, index in class_dict.items():
+                if threshold:
+                    # For thresholding predictions
+                    if index == y and proba >= threshold:
+                        shutil.copy(os.path.join(unlabeled_path, path),
+                                    os.path.join(pseudo_data_path, class_name))
+                else:
+                    # For hard predictions
+                    if index == y:
+                        shutil.copy(os.path.join(unlabeled_path, path),
+                                    os.path.join(pseudo_data_path, class_name))
+        print("Generated pseudo labels.")
+
+        if not os.path.exists("outputs"):
+            os.mkdir("outputs")
+        if save_confidences_csv:
+            print("Saving CSV with pseudo predictions.")
+            data = {'filepaths': raw_predictions_paths,
+                    'class preds highest': raw_predictions,
+                    'class preds all': raw_predictions_all}
+            df = pd.DataFrame(data)
+            df.to_csv("outputs/pseudo_predictions.csv", index=False)
+
+        if plot_confidences:
+            # Plot graph for highest confidence pseudo labels for each class
+            for idx in range(len(class_names)):
+                predictions = []
+                samples = []
+                for i in raw_predictions_all:
+                    predictions.append(i[0][idx])
+
+                predictions = sorted(predictions)
+                samples = [pred for pred in range(len(predictions))]
+                plt.bar(samples, predictions, color='g')
+                plt.axhline(y=0.5, color='r', linestyle='--')
+                plt.title("Confidences for the class: {}".format(
+                    class_names[idx]), size=16)
+                plt.xlabel("Number of unlabelled images", size=16)
+                plt.ylim([0.0, 1.0])
+                plt.ylabel("Probability", size=16)
+                plt.tick_params(labelright=True)
+                plt.savefig(
+                    "outputs/{}_confidences.png".format(class_names[idx]), dpi=100)
+                plt.clf()  # clear buffer, otherwise plot overlap!
+
+            # Plot graph for highest confidence pseudo labels for all unlabeled images
+            predictions_highest = sorted(raw_predictions)
+            samples_highest = [pred for pred in range(len(raw_predictions))]
+            plt.bar(samples_highest, predictions_highest, color='g')
+            plt.title("Highest confidence pseudo labels", size=16)
+            plt.xlabel("Number of unlabelled images", size=16)
+            plt.ylim([0.0, 1.0])
+            plt.ylabel("Probability", size=16)
+            plt.tick_params(labelright=True)
+            plt.savefig("outputs/highest_confidence_predictions.png", dpi=100)
+            plt.clf()
+
+
+if __name__ == '__main__':
+    transformer = PseudoLabelGenerator()

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -98,7 +98,6 @@ class PseudoLabelGenerator:
         # Plot graph for highest confidence pseudo labels for each class
         for idx in range(len(classes)):
             predictions = []
-            samples = []
             for i in raw_predictions_all:
                 predictions.append(i[idx])
 
@@ -174,7 +173,6 @@ class PseudoLabelGenerator:
         raw_predictions = []  # single confidence value of predicted class
         predicted_class = []  # predicted class index
         raw_predictions_all = []  # confidences for all classes
-        pseudo_class_names = []  # name of pseudo class
         for path in tqdm(unlabeled_image_paths[:100]):
             # Load the image
             img = np.array(self._load_img(os.path.join(self.unlabeled_path, path),

--- a/decavision/dataset_preparation/generate_pseudolabels.py
+++ b/decavision/dataset_preparation/generate_pseudolabels.py
@@ -1,5 +1,3 @@
-import csv
-import math
 import os
 import pandas as pd
 import tensorflow as tf
@@ -7,7 +5,6 @@ import numpy as np
 import shutil
 import matplotlib.pyplot as plt
 
-from PIL import Image
 from tensorflow.keras.models import load_model
 from distutils.dir_util import copy_tree
 from tqdm import tqdm
@@ -55,7 +52,7 @@ class PseudoLabelGenerator:
                 pseudo_path (str): path to store train data and pseudo data
                 save_confidences_csv (boolean): Whether to save CSV file with pseudo confidences, default is False.
                 plot_confidences (boolean): Whether to plot confidence graphs for raw confidences and per class confidences.
-                threshold (float): Discard images with prediction below this confidence, default is None. 
+                threshold (float): Discard images with prediction below this confidence, default is None.
 
             Returns:
                 pseudo_data_path: A folder with both labeled and pseudo labeled images.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pyunpack==0.2.2
 scikit-learn==0.23.2
 scikit-optimize==0.8.1
 seaborn==0.11.0
-tensorflow==2.3.1
+tensorflow==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scikit-learn==0.23.2
 scikit-optimize==0.8.1
 seaborn==0.11.0
 tensorflow==2.4.0
+tqdm==4.60.0


### PR DESCRIPTION
Example code snippet to run the new feature: 

```
import decavision

pseudolabels = decavision.dataset_preparation.generate_pseudolabels.PseudoLabelGenerator()
pseudolabels.generate_pseudolabel_data(model_path="logs/yogapose_teacher/yogapose_teacher.h5",
                                    train_data_path="datasets/yogapose/train",
                                    unlabeled_path="datasets/yogapose/unlabeled",
                                    pseudo_data_path="datasets/yogapose/train_ssl",
                                    save_confidences_csv=True,
                                    plot_confidences=True,
                                    threshold=None)
```